### PR TITLE
Support sending additional params on confirm

### DIFF
--- a/resources/views/components/scripts.blade.php
+++ b/resources/views/components/scripts.blade.php
@@ -14,7 +14,7 @@ window.addEventListener('confirming', confirming => {
             confirmButtonText: event.detail.options.confirmButtonText ?? 'Yes',
             ...event.detail.options
         }).then((result) => {
-            if (result.isConfirmed) { Livewire.emit(event.detail.onConfirmed); }
+            if (result.isConfirmed) { Livewire.emit(event.detail.onConfirmed,event.detail.options["inputAttributes"]); }
             else { const cancelCallback = event.detail.onCancelled; if (!cancelCallback) { return; } Livewire.emit(cancelCallback) }
         })
     });


### PR DESCRIPTION
This small change will allow sending additional attributes to the onConfirmed function.
```
        $this->confirm('Delete?', [
            "text" => "Are you sure you want to proceed?",
            'onConfirmed' => 'confirmedDelete',
            'inputAttributes' => ["id"=>$id],
            'onCancelled' => 'cancelled'
        ]);

```