### PR TITLE
Fix js errors in old browsers

### DIFF
--- a/resources/views/components/scripts.blade.php
+++ b/resources/views/components/scripts.blade.php
@@ -1,35 +1,52 @@
 <script>
+    "use strict";
 
-window.addEventListener('alert', event => {
-    Swal.fire({
-        title: event.detail.message ?? '',
-        icon: event.detail.type ?? null,
-        ...event.detail.options
-    })
-});
+    window.addEventListener('alert', event => {
+        var _event$detail$message, _event$detail$type;
 
-window.addEventListener('confirming', confirming => {
-    window.addEventListener(confirming.detail, event => {
-        Swal.fire({
-            confirmButtonText: event.detail.options.confirmButtonText ?? 'Yes',
-            ...event.detail.options
-        }).then((result) => {
-            if (result.isConfirmed) { Livewire.emit(event.detail.onConfirmed,event.detail.options["inputAttributes"]); }
-            else { const cancelCallback = event.detail.onCancelled; if (!cancelCallback) { return; } Livewire.emit(cancelCallback) }
-        })
+        Swal.fire(Object.assign({}, {
+            title: (_event$detail$message = event.detail.message) !== null && _event$detail$message !== void 0 ? _event$detail$message : '',
+            icon: (_event$detail$type = event.detail.type) !== null && _event$detail$type !== void 0 ? _event$detail$type : null,
+        }, event.detail.options));
     });
-});
+    window.addEventListener('confirming', confirming => {
+        window.addEventListener(confirming.detail, event => {
+            var _event$detail$options;
+
+            Swal.fire(Object.assign(
+                {}, {
+                    confirmButtonText: (_event$detail$options = event.detail.options.confirmButtonText) !== null && _event$detail$options !== void 0 ? _event$detail$options : 'Yes',
+                }, event.detail.options
+            )).then(result => {
+                if (result.isConfirmed) {
+                    Livewire.emit(event.detail.onConfirmed, event.detail.options["inputAttributes"]);
+                } else {
+                    const cancelCallback = event.detail.onCancelled;
+
+                    if (!cancelCallback) {
+                        return;
+                    }
+
+                    Livewire.emit(cancelCallback);
+                }
+            });
+        });
+    });
 </script>
 
 @if (session()->has('livewire-alert'))
     <script>
-        window.onload = (event) => {
+        "use strict";
+
+        window.onload = event => {
+            var _flash$message, _flash$type;
+
             const flash = @json(session('livewire-alert'));
             Swal.fire({
-                title: flash.message ?? '',
-                icon: flash.type ?? null,
+                title: (_flash$message = flash.message) !== null && _flash$message !== void 0 ? _flash$message : '',
+                icon: (_flash$type = flash.type) !== null && _flash$type !== void 0 ? _flash$type : null,
                 ...flash.options
-            })
-       };
+            });
+        };
     </script>
 @endif


### PR DESCRIPTION
In old browsers the javascript like spread operator was giving errors making the component to not work so I made the javascript as vanilla as possible