### PR TITLE
:bug: bug fixes empty events

### DIFF
--- a/src/LivewireAlert.php
+++ b/src/LivewireAlert.php
@@ -166,7 +166,11 @@ trait LivewireAlert
             'inputOptions',
             'inputAutoTrim',
             'inputAttributes',
-            'events'
+            'events',
+            'onConfirmed', 
+            'onDismissed', 
+            'onDenied',
+            'onProgressFinished'
         ];
     }
 }


### PR DESCRIPTION
all events not triggered because `$options` only get config from `$this->configurationKeys()`. 
so` 'events' => Arr::only($options, $this->livewireAlertEvents()),` will make events == []