### PR TITLE
Allow empty string type

### DIFF
--- a/src/LivewireAlert.php
+++ b/src/LivewireAlert.php
@@ -123,6 +123,7 @@ trait LivewireAlert
     protected function livewireAlertIcons(): array
     {
         return [
+            '',
             'success',
             'info',
             'warning',


### PR DESCRIPTION
If type is empty string then swal doesn't show any icon