### PR TITLE
Defer loading scripts

### DIFF
--- a/resources/views/components/flash.blade.php
+++ b/resources/views/components/flash.blade.php
@@ -1,5 +1,5 @@
 @if (session()->has('livewire-alert'))
-    <script>
+    <script type="module">
         flashAlert(@json(session('livewire-alert')))
     </script>
 @endif

--- a/resources/views/components/scripts.blade.php
+++ b/resources/views/components/scripts.blade.php
@@ -1,4 +1,4 @@
-<script type="module">
+<script>
     /**** Livewire Alert Scripts ****/
     {!! file_get_contents($jsPath) !!}
 </script>

--- a/resources/views/components/scripts.blade.php
+++ b/resources/views/components/scripts.blade.php
@@ -1,4 +1,4 @@
-<script>
+<script type="module">
     /**** Livewire Alert Scripts ****/
     {!! file_get_contents($jsPath) !!}
 </script>


### PR DESCRIPTION
As Swal is external dependency, when Swal is loaded via vite bundler, it is deferred. Hence when using flash feature, we get error `Uncaught (in promise) ReferenceError: Swal is not defined`. This is because script inside flash is not deferred, adding `type="module"` to the `<script>` fixes that.