### PR TITLE
feat: add Laravel 13 and PHP 8.2+ support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1|^8.2|^8.3|^8.4",
         "livewire/livewire": "^3.0|^4.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.70",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^9.5|^10.0|^11.5.3"
+        "phpunit/phpunit": "^9.5|^10.0|^11.5.3|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "livewire/livewire": "^3.0|^4.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.70",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.5|^10.0|^11.5.3"
     },


### PR DESCRIPTION
## Changes

- Extend `illuminate/support` constraint to include `^13.0` (Laravel 13 compatibility)
- Update PHP constraint from `^8.1` to `^8.2` (Laravel 13 minimum requirement)
- Extend `orchestra/testbench` dev dependency to include `^11.0` for Laravel 13 testing

## Motivation

Laravel 13 merges `illuminate/*` into `laravel/framework`. The current `illuminate/support: ^10.0|^11.0|^12.0` constraint blocks `composer update` when upgrading to Laravel 13. This PR adds `^13.0` to unblock projects wanting to upgrade to Laravel 13.

## Note

`livewire/livewire ^4.0` support was already present in v4.0.8 of this package.